### PR TITLE
Fix case in a couple of includes (Marlin.h, Configuration.h).

### DIFF
--- a/Marlin/UltiLCD2.cpp
+++ b/Marlin/UltiLCD2.cpp
@@ -1,4 +1,4 @@
-#include "configuration.h"
+#include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
 #include "UltiLCD2.h"
 #include "UltiLCD2_hi_lib.h"

--- a/Marlin/UltiLCD2_gfx.cpp
+++ b/Marlin/UltiLCD2_gfx.cpp
@@ -1,4 +1,4 @@
-#include "configuration.h"
+#include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
 #include "UltiLCD2_gfx.h"
 

--- a/Marlin/UltiLCD2_hi_lib.cpp
+++ b/Marlin/UltiLCD2_hi_lib.cpp
@@ -1,7 +1,7 @@
 #include <avr/pgmspace.h>
 #include <string.h>
 
-#include "configuration.h"
+#include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
 #include "UltiLCD2_hi_lib.h"
 

--- a/Marlin/UltiLCD2_menu_first_run.cpp
+++ b/Marlin/UltiLCD2_menu_first_run.cpp
@@ -2,7 +2,7 @@
 
 #include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
-#include "marlin.h"
+#include "Marlin.h"
 #include "cardreader.h"//This code uses the card.longFilename as buffer to store data, to save memory.
 #include "temperature.h"
 #include "ConfigurationStore.h"

--- a/Marlin/UltiLCD2_menu_maintenance.cpp
+++ b/Marlin/UltiLCD2_menu_maintenance.cpp
@@ -1,4 +1,4 @@
-#include "configuration.h"
+#include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
 #include "UltiLCD2.h"
 #include "UltiLCD2_hi_lib.h"

--- a/Marlin/UltiLCD2_menu_material.cpp
+++ b/Marlin/UltiLCD2_menu_material.cpp
@@ -2,7 +2,7 @@
 
 #include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
-#include "marlin.h"
+#include "Marlin.h"
 #include "cardreader.h"//This code uses the card.longFilename as buffer to store data, to save memory.
 #include "temperature.h"
 #include "UltiLCD2.h"

--- a/Marlin/UltiLCD2_menu_print.cpp
+++ b/Marlin/UltiLCD2_menu_print.cpp
@@ -2,7 +2,7 @@
 
 #include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
-#include "marlin.h"
+#include "Marlin.h"
 #include "cardreader.h"
 #include "temperature.h"
 #include "UltiLCD2.h"


### PR DESCRIPTION
This fixes Ultimaker2Marlin build on case-sensitive file systems like one usually has on Linux.

W/o the fix:

```
  CXX   /usr/share/arduino//hardware/arduino/cores/arduino/Tone.cpp
  CXX   UltiLCD2.cpp
UltiLCD2.cpp:1:27: fatal error: configuration.h: No such file or directory
 #include "configuration.h"
                           ^
compilation terminated.
make: *** [applet/UltiLCD2.o] Error 1
```

With the fix:

```
  CXX   applet/Marlin.elf
  COPY  applet/Marlin.hex


AVR Memory Usage
----------------
Device: atmega2560

Program:  110004 bytes (42.0% Full)
(.text + .data + .bootloader)

Data:       5474 bytes (66.8% Full)
(.data + .bss + .noinit)


   text    data     bss     dec     hex filename
 109466     538    4936  114940   1c0fc applet/Marlin.elf
```

I tried to preserve `\r\n` ends of lines, but it's better to verify.
