### PR TITLE
add lifetime_stats to Makefile; include UM2 in board type 72 comment

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -38,7 +38,7 @@
 // 65 = Azteeg X1
 // 7  = Ultimaker
 // 71 = Ultimaker (Older electronics. Pre 1.5.4. This is rare)
-// 72 = Ultiboard v2.0
+// 72 = Ultiboard v2.0 (includes Ultimaker 2)
 // 77 = 3Drag Controller
 // 8  = Teensylu
 // 80 = Rumba

--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -219,7 +219,7 @@ CXXSRC = WMath.cpp WString.cpp Print.cpp Marlin_main.cpp	\
 CXXSRC += LiquidCrystal.cpp ultralcd.cpp SPI.cpp Servo.cpp Tone.cpp
 CXXSRC += UltiLCD2.cpp UltiLCD2_gfx.cpp UltiLCD2_hi_lib.cpp UltiLCD2_low_lib.cpp \
 	UltiLCD2_menu_first_run.cpp UltiLCD2_menu_maintenance.cpp UltiLCD2_menu_material.cpp \
-	UltiLCD2_menu_print.cpp
+	UltiLCD2_menu_print.cpp lifetime_stats.cpp
 
 #Check for Arduino 1.0.0 or higher and use the correct sourcefiles for that version
 ifeq ($(shell [ $(ARDUINO_VERSION) -ge 100 ] && echo true), true)


### PR DESCRIPTION
Hi Daid,

Makefile builds of 14.06.1 work correctly after this tweak.  Touch testing of 14.06.1 otherwise looks good as far as I can tell; haven't printed anything complex with it yet.

Steve
