### PR TITLE
Fix various print startup issues

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -567,6 +567,16 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 //#define SERVO_ENDSTOPS {-1, -1, 0} // Servo index for X, Y, Z. Disable with -1
 //#define SERVO_ENDSTOP_ANGLES {0,0, 0,0, 70,0} // X,Y,Z Axis Extend and Retract angles
 
+
+// Configuration of behaviors at the start and end of prints
+#define END_OF_PRINT_RETRACTION 20		// number of mm to retract when printer goes idle
+#define END_OF_PRINT_RECOVERY_SPEED 5 	// speed to recover that assumed retraction at (mm/s)
+#define PRIMING_MM3	30					// number of mm^3 of plastic to extrude when priming
+										// (Ultimaker 2 hot end capacity is approx 80 mm^3)
+#define PRIMING_MM3_PER_SEC 5			// Rate at which to prime head (in mm^3/s)
+										// (Ultimaker 2 upper limit is 8-10)
+#define PRIMING_HEIGHT 20				// Height at which to perform the priming extrusions
+
 #include "Configuration_adv.h"
 #include "thermistortables.h"
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -67,7 +67,7 @@
 // G28 - Home all Axis
 // G90 - Use Absolute Coordinates
 // G91 - Use Relative Coordinates
-// G92 - Set current position to cordinates given
+// G92 - Set current position to coordinates given
 
 //RepRap M Codes
 // M0   - Unconditional stop - Wait for user to press a button on the LCD (Only if ULTRA_LCD is enabled)
@@ -1618,7 +1618,7 @@ void process_commands()
         if(code_seen(axis_codes[i])) max_feedrate[i] = code_value();
       }
       break;
-    case 204: // M204 acclereration S normal moves T filmanent only moves
+    case 204: // M204 acceleration: S - normal moves;  T - filament only moves
       {
         if(code_seen('S')) acceleration = code_value() ;
         if(code_seen('T')) retract_acceleration = code_value() ;
@@ -1634,14 +1634,14 @@ void process_commands()
       if(code_seen('E')) max_e_jerk = code_value() ;
     }
     break;
-    case 206: // M206 additional homeing offset
+    case 206: // M206 additional homing offset
       for(int8_t i=0; i < 3; i++)
       {
         if(code_seen(axis_codes[i])) add_homeing[i] = code_value();
       }
       break;
     #ifdef FWRETRACT
-    case 207: //M207 - set retract length S[positive mm] F[feedrate mm/sec] Z[additional zlift/hop]
+    case 207: //M207 - set retract length S[positive mm] F[feedrate mm/min] Z[additional zlift/hop]
     {
       if(code_seen('S'))
       {
@@ -1656,7 +1656,7 @@ void process_commands()
         retract_zlift = code_value() ;
       }
     }break;
-    case 208: // M208 - set retract recover length S[positive mm surplus to the M207 S*] F[feedrate mm/sec]
+    case 208: // M208 - set retract recover length S[positive mm surplus to the M207 S*] F[feedrate mm/min]
     {
       if(code_seen('S'))
       {

--- a/Marlin/UltiLCD2_menu_material.cpp
+++ b/Marlin/UltiLCD2_menu_material.cpp
@@ -256,9 +256,10 @@ static void lcd_menu_change_material_insert_forward()
 
 static void materialInsertReady()
 {
-    current_position[E_AXIS] -= 20;
+    current_position[E_AXIS] -= END_OF_PRINT_RETRACTION;
     plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 25*60, active_extruder);
     cancelMaterialInsert();
+
 }
 
 static void lcd_menu_change_material_insert()
@@ -527,7 +528,7 @@ void lcd_material_reset_defaults()
     strcpy_P(buffer, PSTR("PLA"));
     eeprom_write_block(buffer, EEPROM_MATERIAL_NAME_OFFSET(0), 4);
     eeprom_write_word(EEPROM_MATERIAL_TEMPERATURE_OFFSET(0), 210);
-    eeprom_write_word(EEPROM_MATERIAL_BED_TEMPERATURE_OFFSET(0), 75);
+    eeprom_write_word(EEPROM_MATERIAL_BED_TEMPERATURE_OFFSET(0), 60);
     eeprom_write_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(0), 100);
     eeprom_write_word(EEPROM_MATERIAL_FLOW_OFFSET(0), 100);
     eeprom_write_float(EEPROM_MATERIAL_DIAMETER_OFFSET(0), 2.85);

--- a/Marlin/UltiLCD2_menu_print.cpp
+++ b/Marlin/UltiLCD2_menu_print.cpp
@@ -49,11 +49,17 @@ static void abortPrint()
     char buffer[32];
     if (card.sdprinting)
     {
+    	// we're not printing any more
         card.sdprinting = false;
-        sprintf_P(buffer, PSTR("G92 E%i"), int(20.0 / volume_to_filament_length[active_extruder]));
-        enquecommand(buffer);
-        enquecommand_P(PSTR("G1 F1500 E0"));
     }
+
+    // set up the end of print retraction
+    sprintf_P(buffer, PSTR("G92 E%i"), int(((float)END_OF_PRINT_RETRACTION) / volume_to_filament_length[active_extruder]));
+    enquecommand(buffer);
+    // perform the retraction at the standard retract speed
+    sprintf_P(buffer, PSTR("G1 F%i E0"), int(retract_feedrate));
+    enquecommand(buffer);
+
     enquecommand_P(PSTR("G28"));
     enquecommand_P(PSTR("M84"));
 }
@@ -76,22 +82,40 @@ static void checkPrintFinished()
 
 static void doStartPrint()
 {
-    plan_set_e_position(0);
-    current_position[Z_AXIS] = 20.0;
+	// zero the extruder position
+	current_position[E_AXIS] = 0.0;
+	plan_set_e_position(0);
+
+	// since we are going to prime the nozzle, forget about any G10/G11 retractions that happened at end of previous print
+	retracted = false;
+
+	// move to priming height
+    current_position[Z_AXIS] = PRIMING_HEIGHT;
     plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], homing_feedrate[Z_AXIS], 0);
+
     for(uint8_t e = 0; e<EXTRUDERS; e++)
     {
         if (!LCD_DETAIL_CACHE_MATERIAL(e))
+        {
+        	// don't prime the extruder if it isn't used in the (Ulti)gcode
+        	// traditional gcode files typically won't have the Material lines at start, so we won't prime for those
             continue;
+        }
         active_extruder = e;
-        plan_set_e_position(-30.0 / volume_to_filament_length[e]);
-        current_position[E_AXIS] = 0.0;
-        plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 10, e);
-        
+
+        // undo the end-of-print retraction
+        plan_set_e_position((0.0 - END_OF_PRINT_RETRACTION) / volume_to_filament_length[e]);
+        plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], END_OF_PRINT_RECOVERY_SPEED, e);
+
+        // perform additional priming
+        plan_set_e_position(-PRIMING_MM3);
+        plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], (PRIMING_MM3_PER_SEC * volume_to_filament_length[e]), e);
+
+        // for extruders other than the first one, perform end of print retraction
         if (e > 0)
         {
-            plan_set_e_position(20.0 / volume_to_filament_length[e]);
-            plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 20, e);
+            plan_set_e_position((END_OF_PRINT_RETRACTION) / volume_to_filament_length[e]);
+            plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], retract_feedrate/60, e);
         }
     }
     active_extruder = 0;


### PR DESCRIPTION
Fixes these problems: move to old e coord during bed raise; excessively fast priming; remembering retraction status from previous prints; not doing a large retraction when prints complete normally. 

Also set the default for PLA bed to 60º, and corrected some typos.
