### PR TITLE
reduce jitter during display of temperatures - use a moving average

### DIFF
--- a/Marlin/UltiLCD2.cpp
+++ b/Marlin/UltiLCD2.cpp
@@ -13,11 +13,16 @@
 #include "pins.h"
 
 #define SERIAL_CONTROL_TIMEOUT 5000
+// coefficient for the exponential moving average
+#define ALPHA 0.05f
+#define ONE_MINUS_ALPHA 0.95f
 
 unsigned long lastSerialCommandTime;
 bool serialScreenShown;
 uint8_t led_brightness_level = 100;
 uint8_t led_mode = LED_MODE_ALWAYS_ON;
+float dsp_temperature[EXTRUDERS] = { 20.0 };
+float dsp_temperature_bed = 20.0;
 
 //#define SPECIAL_STARTUP
 
@@ -107,6 +112,12 @@ void lcd_update()
         lcd_lib_update_screen();
     }else{
         serialScreenShown = false;
+        // refresh the displayed temperatures
+        for(uint8_t e=0;e<EXTRUDERS;e++)
+        {
+            dsp_temperature[e] = (ALPHA * current_temperature[e]) + (ONE_MINUS_ALPHA * dsp_temperature[e]);
+        }
+        dsp_temperature_bed = (ALPHA * current_temperature_bed) + (ONE_MINUS_ALPHA * dsp_temperature_bed);
         currentMenu();
         if (postMenuCheck) postMenuCheck();
     }

--- a/Marlin/UltiLCD2.h
+++ b/Marlin/UltiLCD2.h
@@ -19,6 +19,8 @@ FORCE_INLINE void lcd_buzz(long duration,uint16_t freq) {}
 extern unsigned long lastSerialCommandTime;
 extern uint8_t led_brightness_level;
 extern uint8_t led_mode;
+extern float dsp_temperature[EXTRUDERS];
+extern float dsp_temperature_bed;
 #define LED_MODE_ALWAYS_ON      0
 #define LED_MODE_ALWAYS_OFF     1
 #define LED_MODE_WHILE_PRINTING 2

--- a/Marlin/UltiLCD2_menu_maintenance.cpp
+++ b/Marlin/UltiLCD2_menu_maintenance.cpp
@@ -100,18 +100,18 @@ static void lcd_advanced_details(uint8_t nr)
         int_to_string(led_brightness_level, buffer, PSTR("%"));
     }else if (nr == 2)
     {
-        int_to_string(int(current_temperature[0]), buffer, PSTR("C/"));
+        int_to_string(int(dsp_temperature[0]), buffer, PSTR("C/"));
         int_to_string(int(target_temperature[0]), buffer+strlen(buffer), PSTR("C"));
 #if EXTRUDERS > 1
     }else if (nr == 3)
     {
-        int_to_string(int(current_temperature[1]), buffer, PSTR("C/"));
+        int_to_string(int(dsp_temperature[1]), buffer, PSTR("C/"));
         int_to_string(int(target_temperature[1]), buffer+strlen(buffer), PSTR("C"));
 #endif
 #if TEMP_SENSOR_BED != 0
     }else if (nr == 2 + EXTRUDERS)
     {
-        int_to_string(int(current_temperature_bed), buffer, PSTR("C/"));
+        int_to_string(int(dsp_temperature_bed), buffer, PSTR("C/"));
         int_to_string(int(target_temperature_bed), buffer+strlen(buffer), PSTR("C"));
 #endif
     }else if (nr == 6 + BED_MENU_OFFSET + EXTRUDERS * 2)
@@ -221,7 +221,7 @@ static void lcd_menu_maintenance_advanced_heatup()
     lcd_lib_draw_string_centerP(20, PSTR("Nozzle temperature:"));
     lcd_lib_draw_string_centerP(53, PSTR("Click to return"));
     char buffer[16];
-    int_to_string(int(current_temperature[active_extruder]), buffer, PSTR("C/"));
+    int_to_string(int(dsp_temperature[active_extruder]), buffer, PSTR("C/"));
     int_to_string(int(target_temperature[active_extruder]), buffer+strlen(buffer), PSTR("C"));
     lcd_lib_draw_string_center(30, buffer);
     lcd_lib_update_screen();
@@ -250,7 +250,7 @@ void lcd_menu_maintenance_extrude()
     lcd_lib_draw_string_centerP(40, PSTR("Rotate to extrude"));
     lcd_lib_draw_string_centerP(53, PSTR("Click to return"));
     char buffer[16];
-    int_to_string(int(current_temperature[active_extruder]), buffer, PSTR("C/"));
+    int_to_string(int(dsp_temperature[active_extruder]), buffer, PSTR("C/"));
     int_to_string(int(target_temperature[active_extruder]), buffer+strlen(buffer), PSTR("C"));
     lcd_lib_draw_string_center(30, buffer);
     lcd_lib_update_screen();
@@ -275,7 +275,7 @@ void lcd_menu_maintenance_advanced_bed_heatup()
     lcd_lib_draw_string_centerP(20, PSTR("Buildplate temp.:"));
     lcd_lib_draw_string_centerP(53, PSTR("Click to return"));
     char buffer[16];
-    int_to_string(int(current_temperature_bed), buffer, PSTR("C/"));
+    int_to_string(int(dsp_temperature_bed), buffer, PSTR("C/"));
     int_to_string(int(target_temperature_bed), buffer+strlen(buffer), PSTR("C"));
     lcd_lib_draw_string_center(30, buffer);
     lcd_lib_update_screen();

--- a/Marlin/UltiLCD2_menu_print.cpp
+++ b/Marlin/UltiLCD2_menu_print.cpp
@@ -495,14 +495,14 @@ static void lcd_menu_print_printing()
         break;
     case PRINT_STATE_HEATING:
         lcd_lib_draw_string_centerP(20, PSTR("Heating"));
-        c = int_to_string(current_temperature[0], buffer, PSTR("C"));
+        c = int_to_string(dsp_temperature[0], buffer, PSTR("C"));
         *c++ = '/';
         c = int_to_string(target_temperature[0], c, PSTR("C"));
         lcd_lib_draw_string_center(30, buffer);
         break;
     case PRINT_STATE_HEATING_BED:
         lcd_lib_draw_string_centerP(20, PSTR("Heating buildplate"));
-        c = int_to_string(current_temperature_bed, buffer, PSTR("C"));
+        c = int_to_string(dsp_temperature_bed, buffer, PSTR("C"));
         *c++ = '/';
         c = int_to_string(target_temperature_bed, c, PSTR("C"));
         lcd_lib_draw_string_center(30, buffer);
@@ -615,8 +615,8 @@ static void lcd_menu_print_ready()
         char buffer[16];
         char* c = buffer;
         for(uint8_t e=0; e<EXTRUDERS; e++)
-            c = int_to_string(current_temperature[e], c, PSTR("C "));
-        int_to_string(current_temperature_bed, c, PSTR("C"));
+            c = int_to_string(dsp_temperature[e], c, PSTR("C "));
+        int_to_string(dsp_temperature_bed, c, PSTR("C"));
         lcd_lib_draw_string_center(25, buffer);
     }else{
         currentMenu = lcd_menu_print_ready_cooled_down;
@@ -696,14 +696,14 @@ static void tune_item_details_callback(uint8_t nr)
         c = int_to_string(feedmultiply, c, PSTR("%"));
     else if (nr == 3)
     {
-        c = int_to_string(current_temperature[0], c, PSTR("C"));
+        c = int_to_string(dsp_temperature[0], c, PSTR("C"));
         *c++ = '/';
         c = int_to_string(target_temperature[0], c, PSTR("C"));
     }
 #if EXTRUDERS > 1
     else if (nr == 4)
     {
-        c = int_to_string(current_temperature[1], c, PSTR("C"));
+        c = int_to_string(dsp_temperature[1], c, PSTR("C"));
         *c++ = '/';
         c = int_to_string(target_temperature[1], c, PSTR("C"));
     }
@@ -711,7 +711,7 @@ static void tune_item_details_callback(uint8_t nr)
 #if TEMP_SENSOR_BED != 0
     else if (nr == 3 + EXTRUDERS)
     {
-        c = int_to_string(current_temperature_bed, c, PSTR("C"));
+        c = int_to_string(dsp_temperature_bed, c, PSTR("C"));
         *c++ = '/';
         c = int_to_string(target_temperature_bed, c, PSTR("C"));
     }
@@ -753,7 +753,7 @@ void lcd_menu_print_tune_heatup_nozzle0()
     lcd_lib_draw_string_centerP(20, PSTR("Nozzle temperature:"));
     lcd_lib_draw_string_centerP(53, PSTR("Click to return"));
     char buffer[16];
-    int_to_string(int(current_temperature[0]), buffer, PSTR("C/"));
+    int_to_string(int(dsp_temperature[0]), buffer, PSTR("C/"));
     int_to_string(int(target_temperature[0]), buffer+strlen(buffer), PSTR("C"));
     lcd_lib_draw_string_center(30, buffer);
     lcd_lib_update_screen();
@@ -777,7 +777,7 @@ void lcd_menu_print_tune_heatup_nozzle1()
     lcd_lib_draw_string_centerP(20, PSTR("Nozzle2 temperature:"));
     lcd_lib_draw_string_centerP(53, PSTR("Click to return"));
     char buffer[16];
-    int_to_string(int(current_temperature[1]), buffer, PSTR("C/"));
+    int_to_string(int(dsp_temperature[1]), buffer, PSTR("C/"));
     int_to_string(int(target_temperature[1]), buffer+strlen(buffer), PSTR("C"));
     lcd_lib_draw_string_center(30, buffer);
     lcd_lib_update_screen();

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -153,7 +153,7 @@ unsigned long watchmillis[EXTRUDERS] = ARRAY_BY_EXTRUDERS(0,0,0);
 #ifndef SOFT_PWM_SCALE
 #define SOFT_PWM_SCALE 0
 #endif
-	
+
 #ifdef HEATER_0_USES_MAX6675
 static int read_max6675();
 #endif
@@ -516,7 +516,7 @@ void manage_heater()
         #endif
       }
     #endif
-    if (pid_output == PID_MAX)
+    if (soft_pwm[e] == (PID_MAX >> 1))
     {
         if (current_temperature[e] - max_heating_start_temperature[e] > MAX_HEATING_TEMPERATURE_INCREASE)
         {


### PR DESCRIPTION
2nd try...
The jittering temperature numbers on the UM2 display are a bit annoying. This change uses a moving average value instead to "smooth" the displayed temperatures, but leaves the primary values untouched.