### PR TITLE
heater verification - compare with the effective pwm value

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -153,7 +153,7 @@ unsigned long watchmillis[EXTRUDERS] = ARRAY_BY_EXTRUDERS(0,0,0);
 #ifndef SOFT_PWM_SCALE
 #define SOFT_PWM_SCALE 0
 #endif
-	
+
 #ifdef HEATER_0_USES_MAX6675
 static int read_max6675();
 #endif
@@ -516,7 +516,7 @@ void manage_heater()
         #endif
       }
     #endif
-    if (pid_output == PID_MAX)
+    if (soft_pwm[e] == (PID_MAX >> 1))
     {
         if (current_temperature[e] - max_heating_start_temperature[e] > MAX_HEATING_TEMPERATURE_INCREASE)
         {


### PR DESCRIPTION
To verify heater and sensor we should compare with the effective pwm value.
This avoids floating point comparisations and takes into account that the pwm is only set, if temperature is within the correct range (see line 484). In other cases the calculated pid_value is refused - so i would prefer to not use this variable afterwards for verification.
What do you think?
