### PR TITLE
init fanSpeed

### DIFF
--- a/Marlin/UltiLCD2_menu_print.cpp
+++ b/Marlin/UltiLCD2_menu_print.cpp
@@ -378,7 +378,7 @@ void lcd_menu_print_select()
 #if TEMP_SENSOR_BED != 0
                             target_temperature_bed = max(target_temperature_bed, material[e].bed_temperature);
 #endif
-                            fanSpeedPercent = max(fanSpeedPercent, material[0].fan_speed);
+                            fanSpeedPercent = max(fanSpeedPercent, material[e].fan_speed);
                             volume_to_filament_length[e] = 1.0 / (M_PI * (material[e].diameter / 2.0) * (material[e].diameter / 2.0));
                             extrudemultiply[e] = material[e].flow;
                         }


### PR DESCRIPTION
In this loop the "fanSpeedPercent" is always initialized from the first material profile. I assume this was not intended...?