### PR TITLE
Add new temperature sensor code to Makefile

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -219,7 +219,8 @@ CXXSRC = WMath.cpp WString.cpp Print.cpp Marlin_main.cpp	\
 CXXSRC += LiquidCrystal.cpp ultralcd.cpp SPI.cpp Servo.cpp Tone.cpp
 CXXSRC += UltiLCD2.cpp UltiLCD2_gfx.cpp UltiLCD2_hi_lib.cpp UltiLCD2_low_lib.cpp \
 	UltiLCD2_menu_first_run.cpp UltiLCD2_menu_maintenance.cpp UltiLCD2_menu_material.cpp \
-	UltiLCD2_menu_print.cpp lifetime_stats.cpp
+	UltiLCD2_menu_print.cpp lifetime_stats.cpp i2c_capacitance.cpp i2c_driver.cpp \
+	fan_driver.cpp temperature_ADS101X.cpp
 
 #Check for Arduino 1.0.0 or higher and use the correct sourcefiles for that version
 ifeq ($(shell [ $(ARDUINO_VERSION) -ge 100 ] && echo true), true)

--- a/Marlin/temperature_ADS101X.cpp
+++ b/Marlin/temperature_ADS101X.cpp
@@ -1,7 +1,7 @@
 #include <avr/io.h>
 #include <util/delay.h>
 
-#include "marlin.h"
+#include "Marlin.h"
 
 #include "temperature_ADS101X.h"
 #include "i2c_driver.h"


### PR DESCRIPTION
the new temperature sensor code was omitted from the makefile, this patch adds this.

additionally, fix a minor typo preventing compilation on case sensitive file systems.

Signed-off-by: Olliver Schinagl o.schinagl@ultimaker.com