### PR TITLE
UM2LCD: Use proper unlock command

### DIFF
--- a/Marlin/UltiLCD2_low_lib.cpp
+++ b/Marlin/UltiLCD2_low_lib.cpp
@@ -27,7 +27,7 @@
 #define LCD_COMMAND_DISPLAY_OFF             0xAE
 #define LCD_COMMAND_DISPLAY_ON              0xAF
 #define LCD_COMMAND_NOP                     0xE3
-#define LCD_COMMAND_LOCK_COMMANDS           0xDF
+#define LCD_COMMAND_LOCK_COMMANDS           0xFD
 
 #define LCD_COMMAND_SET_ADDRESSING_MODE     0x20
 


### PR DESCRIPTION
The UM2CD code uses 0xdf to unlock the display. This is actually an
invalid command and may result in undefined behavior. The correct unlock
command is 0xfd.

Signed-off-by: Olliver Schinagl <o.schinagl@ultimaker.com>