### PR TITLE
minor corrections for the material change

### DIFF
--- a/Marlin/UltiLCD2_menu_material.cpp
+++ b/Marlin/UltiLCD2_menu_material.cpp
@@ -289,9 +289,8 @@ static void lcd_menu_change_material_insert_forward()
 static void materialInsertReady()
 {
     plan_set_e_position(0);
-    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], -END_OF_PRINT_RETRACTION / volume_to_filament_length[active_extruder], 25*60, active_extruder);
-    cancelMaterialInsert();
-
+    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], -END_OF_PRINT_RETRACTION-retract_length / volume_to_filament_length[active_extruder], 25*60, active_extruder);
+    digipot_current(2, motor_current_setting[2]);//Set E motor power to default.
 }
 
 static void lcd_menu_change_material_insert()
@@ -847,7 +846,7 @@ void lcd_material_store_current_material()
 bool lcd_material_verify_material_settings()
 {
     bool hasUPET = false;
-    
+
     uint8_t cnt = eeprom_read_byte(EEPROM_MATERIAL_COUNT_OFFSET());
     if (cnt < 2 || cnt > EEPROM_MATERIAL_SETTINGS_MAX_COUNT)
         return false;
@@ -883,7 +882,7 @@ bool lcd_material_verify_material_settings()
         eeprom_write_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(cnt), 50);
         eeprom_write_word(EEPROM_MATERIAL_FLOW_OFFSET(cnt), 100);
         eeprom_write_float(EEPROM_MATERIAL_DIAMETER_OFFSET(cnt), 2.85);
-        
+
         eeprom_write_byte(EEPROM_MATERIAL_COUNT_OFFSET(), cnt + 1);
     }
     return true;


### PR DESCRIPTION
Hi David,
damned, i think, there is a good chance that Johannes is right...

source is here:
http://umforum.ultimaker.com/index.php?/topic/9348-getting-close-to-that-release-1501-rc11/#entry91005

The call of "cancelMaterialInsert" leads to a call of "doCooldown" - which sets the target bed temperature and the fan speed to zero...   :-(

And during the M601 command processing there is an additonal retract by "retract_length" which is reverted on resume... So we should take this into account here also...
(see Marlin_main.cpp lines 2124 and 2176 "final unretract")

Caution:
These changes are only based on a quick guess - i've not tested it carefully.
