### PR TITLE
Changed M105 response for EXTRUDERS > 1

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1356,19 +1356,34 @@ void process_commands()
           SERIAL_PROTOCOL_F(degBed(),1);
           SERIAL_PROTOCOLPGM(" /");
           SERIAL_PROTOCOL_F(degTargetBed(),1);
+          SERIAL_PROTOCOLPGM(" B@:");
+          SERIAL_PROTOCOL(getHeaterPower(-1));          
         #endif //TEMP_BED_PIN
+        
+        SERIAL_PROTOCOLPGM(" @:");
+        SERIAL_PROTOCOL(getHeaterPower(tmp_extruder));
+          
+        #if (EXTRUDERS > 1)
+          for (int8_t e = 0; e < EXTRUDERS; ++e) {
+            SERIAL_PROTOCOLPGM(" T");
+            SERIAL_PROTOCOL(e);
+            SERIAL_PROTOCOLPGM(":");
+            SERIAL_PROTOCOL_F(degHotend(e), 1);
+            SERIAL_PROTOCOLPGM(" /");
+            SERIAL_PROTOCOL_F(degTargetHotend(e), 1);
+            SERIAL_PROTOCOLPGM(" @");
+            SERIAL_PROTOCOL(e);
+            SERIAL_PROTOCOLPGM(":");
+            SERIAL_PROTOCOL(getHeaterPower(e));
+          }
+        #endif
       #else
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM(MSG_ERR_NO_THERMISTORS);
       #endif
-
-        SERIAL_PROTOCOLPGM(" @:");
-        SERIAL_PROTOCOL(getHeaterPower(tmp_extruder));
-
-        SERIAL_PROTOCOLPGM(" B@:");
-        SERIAL_PROTOCOL(getHeaterPower(-1));
-
-        SERIAL_PROTOCOLLN("");
+      
+      SERIAL_PROTOCOLLN("");
+      
       return;
       break;
     case 109:


### PR DESCRIPTION
Changed the resonse of M105 for printers with dual (or more)
extruders.
Now the actual and target temperature and also the output
power is
reoprted for each hotend.
Tested with:
-Simplify3D V2.2.2
(shows the temperature of both extruders at the
same
time)
-Repetier-Host V1.0.6 (Graph shows only the actual selected
hotend, the
status bar shows both hotends)