### PR TITLE
Heater timeout

### DIFF
--- a/Marlin/UltiLCD2.cpp
+++ b/Marlin/UltiLCD2.cpp
@@ -118,6 +118,11 @@ void lcd_update()
             dsp_temperature[e] = (ALPHA * current_temperature[e]) + (ONE_MINUS_ALPHA * dsp_temperature[e]);
         }
         dsp_temperature_bed = (ALPHA * current_temperature_bed) + (ONE_MINUS_ALPHA * dsp_temperature_bed);
+        if (!card.sdprinting || card.pause)
+        {
+            // cool down nozzle after timeout
+            check_heater_timeout();
+        }
         currentMenu();
         if (postMenuCheck) postMenuCheck();
     }

--- a/Marlin/UltiLCD2_hi_lib.cpp
+++ b/Marlin/UltiLCD2_hi_lib.cpp
@@ -289,7 +289,6 @@ static void lcd_menu_material_reheat()
     else
         minProgress = progress;
 
-    // lcd_info_screen(lcd_change_to_previous_menu, cancelMaterialInsert);
     lcd_lib_clear();
     lcd_lib_draw_string_centerP(10, PSTR("Heating printhead"));
 
@@ -297,7 +296,6 @@ static void lcd_menu_material_reheat()
     char *c = int_to_string(int(dsp_temperature[active_extruder]), buffer, PSTR("C/"));
     int_to_string(int(target_temperature[active_extruder]), c, PSTR("C"));
     lcd_lib_draw_string_center(24, buffer);
-    // lcd_lib_draw_heater(LCD_GFX_WIDTH/2-2, 40, getHeaterPower(active_extruder));
 
     lcd_progressbar(progress);
 

--- a/Marlin/UltiLCD2_hi_lib.cpp
+++ b/Marlin/UltiLCD2_hi_lib.cpp
@@ -4,10 +4,15 @@
 #include "Configuration.h"
 #ifdef ENABLE_ULTILCD2
 #include "UltiLCD2_hi_lib.h"
+#include "UltiLCD2.h"
+#include "temperature.h"
+
+#define HEATER_TIMEOUT  180   // heater timeout in seconds
 
 menuFunc_t currentMenu;
 menuFunc_t previousMenu;
 menuFunc_t postMenuCheck;
+
 int16_t previousEncoderPos;
 uint8_t led_glow = 0;
 uint8_t led_glow_dir;
@@ -20,16 +25,20 @@ uint8_t lcd_setting_type;
 int16_t lcd_setting_min;
 int16_t lcd_setting_max;
 
-void lcd_change_to_menu(menuFunc_t nextMenu, int16_t newEncoderPos)
+int backup_temperature[EXTRUDERS] = { 0 };
+
+void lcd_change_to_menu(menuFunc_t nextMenu, int16_t newEncoderPos, bool beep)
 {
     minProgress = 0;
     led_glow = led_glow_dir = 0;
     LED_NORMAL();
-    lcd_lib_beep();
     previousMenu = currentMenu;
     previousEncoderPos = lcd_lib_encoder_pos;
     currentMenu = nextMenu;
     lcd_lib_encoder_pos = newEncoderPos;
+    last_user_interaction = millis();
+    if (beep)
+        lcd_lib_beep();
 }
 
 void lcd_tripple_menu(const char* left, const char* right, const char* bottom)
@@ -261,4 +270,72 @@ void lcd_menu_edit_setting()
     if (lcd_lib_button_pressed)
         lcd_change_to_menu(previousMenu, previousEncoderPos);
 }
+
+static void lcd_menu_material_reheat()
+{
+    last_user_interaction = millis();
+    int16_t temp = degHotend(active_extruder);
+    int16_t target = degTargetHotend(active_extruder) - 10;
+    if (temp < 0) temp = 0;
+    if (temp > target)
+    {
+        // return to previous menu
+        lcd_change_to_menu(previousMenu, previousEncoderPos, false);
+    }
+
+    uint8_t progress = uint8_t(temp * 125 / target);
+    if (progress < minProgress)
+        progress = minProgress;
+    else
+        minProgress = progress;
+
+    // lcd_info_screen(lcd_change_to_previous_menu, cancelMaterialInsert);
+    lcd_lib_clear();
+    lcd_lib_draw_string_centerP(10, PSTR("Heating printhead"));
+
+    char buffer[16];
+    char *c = int_to_string(int(dsp_temperature[active_extruder]), buffer, PSTR("C/"));
+    int_to_string(int(target_temperature[active_extruder]), c, PSTR("C"));
+    lcd_lib_draw_string_center(24, buffer);
+    // lcd_lib_draw_heater(LCD_GFX_WIDTH/2-2, 40, getHeaterPower(active_extruder));
+
+    lcd_progressbar(progress);
+
+    lcd_lib_update_screen();
+}
+
+
+bool check_heater_timeout()
+{
+    if (millis()-last_user_interaction > HEATER_TIMEOUT*1000UL)
+    {
+        if (target_temperature[active_extruder])
+        {
+            for(uint8_t n=0; n<EXTRUDERS; ++n)
+            {
+                // switch off nozzle heater
+                backup_temperature[n] = target_temperature[n];
+                setTargetHotend(0, n);
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+bool check_preheat()
+{
+    int16_t target = degTargetHotend(active_extruder);
+    if (!target)
+    {
+        for (uint8_t n=0; n<EXTRUDERS; ++n)
+        {
+            setTargetHotend(backup_temperature[n], n);
+        }
+        lcd_change_to_menu(lcd_menu_material_reheat, ENCODER_NO_SELECTION, false);
+        return false;
+    }
+    return true;
+}
+
 #endif//ENABLE_ULTILCD2

--- a/Marlin/UltiLCD2_hi_lib.h
+++ b/Marlin/UltiLCD2_hi_lib.h
@@ -35,7 +35,6 @@ void lcd_menu_edit_setting();
 bool check_heater_timeout();
 bool check_preheat();
 
-extern uint8_t heater_timeout;
 extern int backup_temperature[EXTRUDERS];
 
 extern const char* lcd_setting_name;

--- a/Marlin/UltiLCD2_hi_lib.h
+++ b/Marlin/UltiLCD2_hi_lib.h
@@ -20,7 +20,7 @@ typedef void (*entryDetailsCallback_t)(uint8_t nr);
 #define IS_SELECTED_MAIN(n) ((n) == SELECTED_MAIN_MENU_ITEM())
 #define IS_SELECTED_SCROLL(n) ((n) == SELECTED_SCROLL_MENU_ITEM())
 
-void lcd_change_to_menu(menuFunc_t nextMenu, int16_t newEncoderPos = ENCODER_NO_SELECTION);
+void lcd_change_to_menu(menuFunc_t nextMenu, int16_t newEncoderPos = ENCODER_NO_SELECTION, bool beep = true);
 
 void lcd_tripple_menu(const char* left, const char* right, const char* bottom);
 void lcd_basic_screen();
@@ -31,6 +31,12 @@ void lcd_scroll_menu(const char* menuNameP, int8_t entryCount, entryNameCallback
 void lcd_progressbar(uint8_t progress);
 
 void lcd_menu_edit_setting();
+
+bool check_heater_timeout();
+bool check_preheat();
+
+extern uint8_t heater_timeout;
+extern int backup_temperature[EXTRUDERS];
 
 extern const char* lcd_setting_name;
 extern const char* lcd_setting_postfix;

--- a/Marlin/UltiLCD2_low_lib.cpp
+++ b/Marlin/UltiLCD2_low_lib.cpp
@@ -41,6 +41,8 @@
 
 #define LCD_COMMAND_SET_ADDRESSING_MODE     0x20
 
+unsigned long last_user_interaction=0;
+
 /** Backbuffer for LCD */
 uint8_t lcd_buffer[LCD_GFX_WIDTH * LCD_GFX_HEIGHT / 8];
 uint8_t led_r, led_g, led_b;
@@ -87,7 +89,7 @@ void lcd_lib_init()
 
     SET_OUTPUT(I2C_SDA_PIN);
     SET_OUTPUT(I2C_SCL_PIN);
-    
+
     //Set unused pins in the 10 pin connector to GND to improve shielding of the cable.
     SET_OUTPUT(LCD_PINS_D4); WRITE(LCD_PINS_D4, 0); //RXD3/PJ1
     SET_OUTPUT(LCD_PINS_ENABLE); WRITE(LCD_PINS_ENABLE, 0); //TXD3/PJ0
@@ -783,12 +785,14 @@ void lcd_lib_buttons_update_interrupt()
 
 void lcd_lib_buttons_update()
 {
-    lcd_lib_encoder_pos += lcd_lib_encoder_pos_interrupt;
-    lcd_lib_encoder_pos_interrupt = 0;
-
     uint8_t buttonState = !READ(BTN_ENC);
     lcd_lib_button_pressed = (buttonState && !lcd_lib_button_down);
     lcd_lib_button_down = buttonState;
+
+    if (lcd_lib_button_down || lcd_lib_encoder_pos_interrupt!=0 ) last_user_interaction=millis();
+
+    lcd_lib_encoder_pos += lcd_lib_encoder_pos_interrupt;
+    lcd_lib_encoder_pos_interrupt = 0;
 }
 
 char* int_to_string(int i, char* temp_buffer, const char* p_postfix)

--- a/Marlin/UltiLCD2_low_lib.h
+++ b/Marlin/UltiLCD2_low_lib.h
@@ -38,6 +38,7 @@ void lcd_lib_led_color(uint8_t r, uint8_t g, uint8_t b);
 extern int16_t lcd_lib_encoder_pos;
 extern bool lcd_lib_button_pressed;
 extern bool lcd_lib_button_down;
+extern unsigned long last_user_interaction;
 
 char* int_to_string(int i, char* temp_buffer, const char* p_postfix = NULL);
 char* int_to_time_string(unsigned long i, char* temp_buffer);

--- a/Marlin/UltiLCD2_menu_maintenance.cpp
+++ b/Marlin/UltiLCD2_menu_maintenance.cpp
@@ -181,7 +181,7 @@ static void lcd_menu_maintenance_advanced()
             enquecommand_P(PSTR("G28 X0 Y0"));
             sprintf_P(buffer, PSTR("G1 F%i X%i Y%i"), int(homing_feedrate[0]), X_MAX_LENGTH/2, 10);
             enquecommand(buffer);
-            
+
             lcd_change_to_menu_insert_material(lcd_menu_maintenance_advanced_return);
         }
         else if (IS_SELECTED_SCROLL(6 + BED_MENU_OFFSET + EXTRUDERS))
@@ -250,11 +250,16 @@ void lcd_menu_maintenance_extrude()
             lcd_lib_encoder_pos = 0;
         }
     }
-    if (lcd_lib_button_pressed)
+    if (lcd_lib_button_pressed || !target_temperature[active_extruder])
     {
         set_extrude_min_temp(EXTRUDE_MINTEMP);
         target_temperature[active_extruder] = 0;
         lcd_change_to_menu(previousMenu, previousEncoderPos);
+    }
+    // reset heater timeout until target temperature is reached
+    if ((degTargetHotend(active_extruder) < 120) || (degHotend(active_extruder) < (degTargetHotend(active_extruder) - 20)))
+    {
+        last_user_interaction = millis();
     }
 
     lcd_lib_clear();

--- a/Marlin/UltiLCD2_menu_material.cpp
+++ b/Marlin/UltiLCD2_menu_material.cpp
@@ -852,7 +852,7 @@ void lcd_material_store_current_material()
 bool lcd_material_verify_material_settings()
 {
     bool hasCPE = false;
-    
+
     uint8_t cnt = eeprom_read_byte(EEPROM_MATERIAL_COUNT_OFFSET());
     if (cnt < 2 || cnt > EEPROM_MATERIAL_SETTINGS_MAX_COUNT)
         return false;
@@ -895,7 +895,7 @@ bool lcd_material_verify_material_settings()
         eeprom_write_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(cnt), 50);
         eeprom_write_word(EEPROM_MATERIAL_FLOW_OFFSET(cnt), 100);
         eeprom_write_float(EEPROM_MATERIAL_DIAMETER_OFFSET(cnt), 2.85);
-        
+
         eeprom_write_byte(EEPROM_MATERIAL_COUNT_OFFSET(), cnt + 1);
     }
     return true;


### PR DESCRIPTION
A (hopefully) more complete solution for the heater timeout - replaces pull request #79.

The goal is to prevent carbonized residues in the (heated) nozzle because of a long time of inactivity (e.g. during material change or a paused print).
- switch off nozzle heater after 3 minutes of inactivity
- heatup nozzle again if necessary (resume print or change material wizard) 
