### PR TITLE
small fix for the M42 command

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1313,7 +1313,7 @@ void process_commands()
         int pin_number = LED_PIN;
         if (code_seen('P') && pin_status >= 0 && pin_status <= 255)
           pin_number = code_value();
-        for(int8_t i = 0; i < (int8_t)sizeof(sensitive_pins); i++)
+        for(uint8_t i = 0; i < (sizeof(sensitive_pins)/sizeof(sensitive_pins[0])); ++i)
         {
           if (sensitive_pins[i] == pin_number)
           {
@@ -1327,8 +1327,6 @@ void process_commands()
       #endif
         if (pin_number > -1)
         {
-          pinMode(pin_number, OUTPUT);
-          digitalWrite(pin_number, pin_status);
           analogWrite(pin_number, pin_status);
         }
       }
@@ -2189,7 +2187,7 @@ void process_commands()
     case 605: // M605 store current set values
     {
       uint8_t tmp_select;
-      if (code_seen('S')) 
+      if (code_seen('S'))
       {
         tmp_select = code_value();
         if (tmp_select>9) tmp_select=9;
@@ -2223,7 +2221,7 @@ void process_commands()
     case 606: // M606 recall saved values
     {
       uint8_t tmp_select;
-      if (code_seen('S')) 
+      if (code_seen('S'))
       {
         tmp_select = code_value();
         if (tmp_select>9) tmp_select=9;


### PR DESCRIPTION
The processing of the M42 command uses a loop to prevent changes on sensitives pins. Unfortunatly the calculation of the array size is wrong and the printer refuses to cooperate if you try to use the M42 command... :disappointed:
After this small fix the printer reacts like intended.