### PR TITLE
Enabled beeping for ULTILCD2

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -1163,6 +1163,8 @@
  #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
 #endif
 
+#define LARGE_FLASH true
+
 #define X_STEP_PIN 25
 #define X_DIR_PIN 23
 #define X_STOP_PIN 22


### PR DESCRIPTION
Enabled beeping for ULTILCD2 by adding this board to the ifdef and enabling LARGE_FLASH for board 72.

Note: LARGE_FLASH is currently only checked for "leaving out" this beeping capability, not anywhere else, so I added Ultimaker's board to have that set to true since this is a valuable capability to have in this case.

Verified to work on master and UM 2Go branch with a UM2 and 2Go.