### PR TITLE
quick fix for material change during print

### DIFF
--- a/Marlin/UltiLCD2_menu_material.cpp
+++ b/Marlin/UltiLCD2_menu_material.cpp
@@ -132,7 +132,7 @@ static void lcd_menu_change_material_preheat()
         if ((signed long)(millis() - preheat_end_time) > 0)
         {
             set_extrude_min_temp(0);
-            
+
             plan_set_e_position(0);
             plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], 20.0 / volume_to_filament_length[active_extruder], retract_feedrate/60.0, active_extruder);
 
@@ -170,7 +170,7 @@ static void lcd_menu_change_material_preheat()
     lcd_info_screen(post_change_material_menu, cancelMaterialInsert);
     lcd_lib_draw_stringP(3, 10, PSTR("Heating printhead"));
     lcd_lib_draw_stringP(3, 20, PSTR("for material removal"));
-    
+
     lcd_progressbar(progress);
 
     lcd_lib_update_screen();
@@ -275,12 +275,9 @@ static void lcd_menu_insert_material_preheat()
     int16_t temp = degHotend(active_extruder) - 20;
     int16_t target = degTargetHotend(active_extruder) - 20 - 10;
     if (temp < 0) temp = 0;
-    if (temp > target && temp < target + 20 && !is_command_queued())
+    if (temp > target && temp < target + 20 && (card.pause || !is_command_queued()))
     {
         set_extrude_min_temp(0);
-        for(uint8_t e=0; e<EXTRUDERS; e++)
-            volume_to_filament_length[e] = 1.0;//Set the extrusion to 1mm per given value, so we can move the filament a set distance.
-
         currentMenu = lcd_menu_change_material_insert_wait_user;
         temp = target;
     }
@@ -466,7 +463,7 @@ static void lcd_menu_material_export()
         ptr = buffer + strlen(buffer);
         float_to_string(eeprom_read_word(EEPROM_MATERIAL_CHANGE_TEMPERATURE(n)), ptr, PSTR("\n\n"));
         card.write_string(buffer);
-        
+
         strcpy_P(buffer, PSTR("change_wait="));
         ptr = buffer + strlen(buffer);
         float_to_string(eeprom_read_byte(EEPROM_MATERIAL_CHANGE_WAIT_TIME(n)), ptr, PSTR("\n\n"));
@@ -922,7 +919,7 @@ void lcd_material_read_current_material()
 
         material[e].fan_speed = eeprom_read_byte(EEPROM_MATERIAL_FAN_SPEED_OFFSET(EEPROM_MATERIAL_SETTINGS_MAX_COUNT+e));
         material[e].diameter = eeprom_read_float(EEPROM_MATERIAL_DIAMETER_OFFSET(EEPROM_MATERIAL_SETTINGS_MAX_COUNT+e));
-        
+
         material[e].change_temperature = eeprom_read_word(EEPROM_MATERIAL_CHANGE_TEMPERATURE(EEPROM_MATERIAL_SETTINGS_MAX_COUNT+e));
         material[e].change_preheat_wait_time = eeprom_read_byte(EEPROM_MATERIAL_CHANGE_WAIT_TIME(EEPROM_MATERIAL_SETTINGS_MAX_COUNT+e));
         if (material[e].change_temperature < 10)
@@ -950,7 +947,7 @@ void lcd_material_store_current_material()
 bool lcd_material_verify_material_settings()
 {
     bool hasCPE = false;
-    
+
     uint8_t cnt = eeprom_read_byte(EEPROM_MATERIAL_COUNT_OFFSET());
     if (cnt < 2 || cnt > EEPROM_MATERIAL_SETTINGS_MAX_COUNT)
         return false;


### PR DESCRIPTION
This fixes the "heating/cooling" endless loop, if the material change wizard is used during a paused print.