### PR TITLE
fix quickstop / position of the e-axis

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -933,7 +933,7 @@ void quickStop()
   current_position[X_AXIS] = float(st_get_position(X_AXIS)) / axis_steps_per_unit[X_AXIS];
   current_position[Y_AXIS] = float(st_get_position(Y_AXIS)) / axis_steps_per_unit[Y_AXIS];
   current_position[Z_AXIS] = float(st_get_position(Z_AXIS)) / axis_steps_per_unit[Z_AXIS];
-  current_position[E_AXIS] = float(st_get_position(E_AXIS)) / axis_steps_per_unit[E_AXIS];
+  current_position[E_AXIS] = (float(st_get_position(E_AXIS))/axis_steps_per_unit[E_AXIS])/volume_to_filament_length[active_extruder];
   plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 }
 


### PR DESCRIPTION
- take the volume multiplier into account for calculation of the E-position